### PR TITLE
Improve responses streaming metrics

### DIFF
--- a/cmd/extproc/mainlib/main.go
+++ b/cmd/extproc/mainlib/main.go
@@ -172,6 +172,7 @@ func Main(ctx context.Context, args []string, stderr io.Writer) (err error) {
 		return fmt.Errorf("failed to create external processor server: %w", err)
 	}
 	server.Register(path.Join(flags.rootPrefix, "/v1/chat/completions"), extproc.ChatCompletionProcessorFactory(chatCompletionMetrics))
+	server.Register(path.Join(flags.rootPrefix, "/v1/responses"), extproc.ResponsesProcessorFactory(chatCompletionMetrics))
 	server.Register(path.Join(flags.rootPrefix, "/v1/embeddings"), extproc.EmbeddingsProcessorFactory(embeddingsMetrics))
 	server.Register(path.Join(flags.rootPrefix, "/v1/models"), extproc.NewModelsProcessor)
 	server.Register(path.Join(flags.rootPrefix, "/anthropic/v1/messages"), extproc.MessagesProcessorFactory(chatCompletionMetrics))

--- a/internal/apischema/openai/openai.go
+++ b/internal/apischema/openai/openai.go
@@ -1161,7 +1161,15 @@ type ResponsesRequest struct {
 	// Model specifies which model should service the request.
 	Model string `json:"model"`
 
-	// Stream enables Server Sent Events streaming when set to true.
+	// Input carries the prompt or conversation content. It is kept as raw
+	// JSON since the gateway only inspects the model and streaming flag
+	// for routing purposes.
+	Input json.RawMessage `json:"input,omitempty"`
+
+	// Stream enables Server Sent Events streaming when set to true. The
+	// upstream API allows this field to be either a boolean or an object
+	// with additional streaming configuration. Any non-false value enables
+	// streaming.
 	Stream bool `json:"stream,omitempty"`
 }
 

--- a/internal/apischema/openai/openai.go
+++ b/internal/apischema/openai/openai.go
@@ -1153,6 +1153,41 @@ type ChatCompletionResponseChunkChoiceDelta struct {
 	Annotations *[]Annotation                        `json:"annotations,omitempty"`
 }
 
+// ResponsesRequest represents the subset of the OpenAI Responses API request
+// used by Envoy Gateway. The structure of the request body is significantly
+// larger in the upstream API, however only the model identifier and streaming
+// indicator are required for routing and token accounting.
+type ResponsesRequest struct {
+	// Model specifies which model should service the request.
+	Model string `json:"model"`
+
+	// Stream enables Server Sent Events streaming when set to true.
+	Stream bool `json:"stream,omitempty"`
+}
+
+// ResponsesUsage captures the token accounting returned as part of the
+// responses endpoint payload.
+type ResponsesUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+	TotalTokens  int `json:"total_tokens"`
+}
+
+// ResponsesResponse is a reduced representation of the Responses API response
+// which focuses on the usage statistics needed by the gateway. All other
+// fields present in the upstream response are forwarded transparently.
+type ResponsesResponse struct {
+	Usage ResponsesUsage `json:"usage"`
+}
+
+// ResponsesStreamEvent models an individual Server Sent Events message emitted
+// by the Responses streaming endpoint. The gateway is interested in
+// `response.completed` events so that the token usage can be extracted.
+type ResponsesStreamEvent struct {
+	Type     string             `json:"type"`
+	Response *ResponsesResponse `json:"response,omitempty"`
+}
+
 // Error is described in the OpenAI API documentation
 // https://platform.openai.com/docs/api-reference/realtime-server-events/error
 type Error struct {

--- a/internal/extproc/mocks_test.go
+++ b/internal/extproc/mocks_test.go
@@ -29,6 +29,7 @@ var (
 	_ Processor                                 = &mockProcessor{}
 	_ translator.OpenAIChatCompletionTranslator = &mockTranslator{}
 	_ translator.OpenAIEmbeddingTranslator      = &mockEmbeddingTranslator{}
+	_ translator.OpenAIResponsesTranslator      = &mockResponsesTranslator{}
 )
 
 func newMockProcessor(_ *processorConfig, _ *slog.Logger) Processor {
@@ -82,6 +83,19 @@ type mockTranslator struct {
 	retHeaderMutation           *extprocv3.HeaderMutation
 	retBodyMutation             *extprocv3.BodyMutation
 	retUsedToken                translator.LLMTokenUsage
+	retLatencyTokens            uint32
+	retErr                      error
+	expForceRequestBodyMutation bool
+}
+
+type mockResponsesTranslator struct {
+	t                           *testing.T
+	expHeaders                  map[string]string
+	expRequestBody              *openai.ResponsesRequest
+	expResponseBody             *extprocv3.HttpBody
+	retHeaderMutation           *extprocv3.HeaderMutation
+	retBodyMutation             *extprocv3.BodyMutation
+	retUsedToken                translator.LLMTokenUsage
 	retErr                      error
 	expForceRequestBodyMutation bool
 }
@@ -117,6 +131,35 @@ func (m mockTranslator) ResponseBody(_ map[string]string, body io.Reader, _ bool
 		require.Equal(m.t, m.expResponseBody.Body, buf)
 	}
 	return m.retHeaderMutation, m.retBodyMutation, m.retUsedToken, m.retErr
+}
+
+func (m mockResponsesTranslator) RequestBody(_ []byte, body *openai.ResponsesRequest, forceRequestBodyMutation bool) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, err error) {
+	require.Equal(m.t, m.expRequestBody, body)
+	require.Equal(m.t, m.expForceRequestBodyMutation, forceRequestBodyMutation)
+	return m.retHeaderMutation, m.retBodyMutation, m.retErr
+}
+
+func (m mockResponsesTranslator) ResponseHeaders(headers map[string]string) (*extprocv3.HeaderMutation, error) {
+	require.Equal(m.t, m.expHeaders, headers)
+	return m.retHeaderMutation, m.retErr
+}
+
+func (m mockResponsesTranslator) ResponseError(_ map[string]string, body io.Reader) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, error) {
+	if m.expResponseBody != nil {
+		buf, err := io.ReadAll(body)
+		require.NoError(m.t, err)
+		require.Equal(m.t, m.expResponseBody.Body, buf)
+	}
+	return m.retHeaderMutation, m.retBodyMutation, m.retErr
+}
+
+func (m mockResponsesTranslator) ResponseBody(_ map[string]string, body io.Reader, _ bool) (*extprocv3.HeaderMutation, *extprocv3.BodyMutation, translator.LLMTokenUsage, uint32, error) {
+	if m.expResponseBody != nil {
+		buf, err := io.ReadAll(body)
+		require.NoError(m.t, err)
+		require.Equal(m.t, m.expResponseBody.Body, buf)
+	}
+	return m.retHeaderMutation, m.retBodyMutation, m.retUsedToken, m.retLatencyTokens, m.retErr
 }
 
 // mockExternalProcessingStream implements [extprocv3.ExternalProcessor_ProcessServer] for testing.

--- a/internal/extproc/responses_processor.go
+++ b/internal/extproc/responses_processor.go
@@ -1,0 +1,372 @@
+package extproc
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"strconv"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocv3http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/envoyproxy/ai-gateway/filterapi"
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/backendauth"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/headermutator"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/translator"
+	"github.com/envoyproxy/ai-gateway/internal/internalapi"
+	"github.com/envoyproxy/ai-gateway/internal/metrics"
+	tracing "github.com/envoyproxy/ai-gateway/internal/tracing/api"
+)
+
+// ResponsesProcessorFactory returns a factory method to instantiate the responses processor.
+func ResponsesProcessorFactory(ccm metrics.ChatCompletionMetrics) ProcessorFactory {
+	return func(config *processorConfig, requestHeaders map[string]string, logger *slog.Logger, _ tracing.Tracing, isUpstreamFilter bool) (Processor, error) {
+		logger = logger.With("processor", "responses", "isUpstreamFilter", fmt.Sprintf("%v", isUpstreamFilter))
+		if !isUpstreamFilter {
+			return &responsesProcessorRouterFilter{
+				config:         config,
+				requestHeaders: requestHeaders,
+				logger:         logger,
+			}, nil
+		}
+		return &responsesProcessorUpstreamFilter{
+			config:         config,
+			requestHeaders: requestHeaders,
+			logger:         logger,
+			metrics:        ccm,
+		}, nil
+	}
+}
+
+type responsesProcessorRouterFilter struct {
+	passThroughProcessor
+	upstreamFilter         Processor
+	logger                 *slog.Logger
+	config                 *processorConfig
+	requestHeaders         map[string]string
+	originalRequestBody    *openai.ResponsesRequest
+	originalRequestBodyRaw []byte
+	upstreamFilterCount    int
+}
+
+func (r *responsesProcessorRouterFilter) ProcessRequestHeaders(_ context.Context, _ *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
+	return &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_RequestHeaders{}}, nil
+}
+
+func (r *responsesProcessorRouterFilter) ProcessRequestBody(_ context.Context, rawBody *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
+	model, body, err := parseOpenAIResponsesBody(rawBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse request body: %w", err)
+	}
+
+	r.requestHeaders[r.config.modelNameHeaderKey] = model
+
+	additionalHeaders := []*corev3.HeaderValueOption{
+		{
+			Header: &corev3.HeaderValue{Key: r.config.modelNameHeaderKey, RawValue: []byte(model)},
+		},
+		{
+			Header: &corev3.HeaderValue{Key: originalPathHeader, RawValue: []byte(r.requestHeaders[":path"])},
+		},
+	}
+
+	r.originalRequestBody = body
+	r.originalRequestBodyRaw = rawBody.Body
+
+	return &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_RequestBody{
+			RequestBody: &extprocv3.BodyResponse{
+				Response: &extprocv3.CommonResponse{
+					HeaderMutation:  &extprocv3.HeaderMutation{SetHeaders: additionalHeaders},
+					ClearRouteCache: true,
+				},
+			},
+		},
+	}, nil
+}
+
+func (r *responsesProcessorRouterFilter) ProcessResponseHeaders(ctx context.Context, headers *corev3.HeaderMap) (*extprocv3.ProcessingResponse, error) {
+	if r.upstreamFilter != nil {
+		return r.upstreamFilter.ProcessResponseHeaders(ctx, headers)
+	}
+	return r.passThroughProcessor.ProcessResponseHeaders(ctx, headers)
+}
+
+func (r *responsesProcessorRouterFilter) ProcessResponseBody(ctx context.Context, body *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
+	if r.upstreamFilter != nil {
+		return r.upstreamFilter.ProcessResponseBody(ctx, body)
+	}
+	return r.passThroughProcessor.ProcessResponseBody(ctx, body)
+}
+
+func (r *responsesProcessorRouterFilter) SetBackend(_ context.Context, _ *filterapi.Backend, _ backendauth.Handler, _ Processor) error {
+	return nil
+}
+
+type responsesProcessorUpstreamFilter struct {
+	logger                 *slog.Logger
+	config                 *processorConfig
+	requestHeaders         map[string]string
+	responseHeaders        map[string]string
+	responseEncoding       string
+	modelNameOverride      string
+	backendName            string
+	handler                backendauth.Handler
+	headerMutator          *headermutator.HeaderMutator
+	originalRequestBodyRaw []byte
+	originalRequestBody    *openai.ResponsesRequest
+	translator             translator.OpenAIResponsesTranslator
+	onRetry                bool
+	costs                  translator.LLMTokenUsage
+	metrics                metrics.ChatCompletionMetrics
+	stream                 bool
+}
+
+func (r *responsesProcessorUpstreamFilter) selectTranslator(out filterapi.VersionedAPISchema) error {
+	switch out.Name {
+	case filterapi.APISchemaOpenAI:
+		r.translator = translator.NewResponsesOpenAIToOpenAITranslator(out.Version, r.modelNameOverride)
+	default:
+		return fmt.Errorf("unsupported API schema: backend=%s", out)
+	}
+	return nil
+}
+
+func (r *responsesProcessorUpstreamFilter) ProcessRequestHeaders(ctx context.Context, _ *corev3.HeaderMap) (resp *extprocv3.ProcessingResponse, err error) {
+	defer func() {
+		if err != nil {
+			r.metrics.RecordRequestCompletion(ctx, false, r.requestHeaders)
+		}
+	}()
+
+	r.metrics.StartRequest(r.requestHeaders)
+	r.metrics.SetModel(r.requestHeaders[r.config.modelNameHeaderKey])
+
+	headerMutation, bodyMutation, err := r.translator.RequestBody(r.originalRequestBodyRaw, r.originalRequestBody, r.onRetry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to transform request: %w", err)
+	}
+
+	if headerMutation == nil {
+		headerMutation = &extprocv3.HeaderMutation{}
+	}
+
+	if h := r.headerMutator; h != nil {
+		if hm := h.Mutate(r.requestHeaders, r.onRetry); hm != nil {
+			headerMutation.RemoveHeaders = append(headerMutation.RemoveHeaders, hm.RemoveHeaders...)
+			headerMutation.SetHeaders = append(headerMutation.SetHeaders, hm.SetHeaders...)
+		}
+	}
+
+	for _, h := range headerMutation.SetHeaders {
+		r.requestHeaders[h.Header.Key] = string(h.Header.RawValue)
+	}
+
+	if h := r.handler; h != nil {
+		if err = h.Do(ctx, r.requestHeaders, headerMutation, bodyMutation); err != nil {
+			return nil, fmt.Errorf("failed to do auth request: %w", err)
+		}
+	}
+
+	var dm *structpb.Struct
+	if bm := bodyMutation.GetBody(); bm != nil {
+		dm = buildContentLengthDynamicMetadataOnRequest(r.config, len(bm))
+	}
+
+	return &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_RequestHeaders{
+			RequestHeaders: &extprocv3.HeadersResponse{
+				Response: &extprocv3.CommonResponse{
+					HeaderMutation: headerMutation,
+					BodyMutation:   bodyMutation,
+					Status:         extprocv3.CommonResponse_CONTINUE_AND_REPLACE,
+				},
+			},
+		},
+		DynamicMetadata: dm,
+	}, nil
+}
+
+func (r *responsesProcessorUpstreamFilter) ProcessRequestBody(context.Context, *extprocv3.HttpBody) (*extprocv3.ProcessingResponse, error) {
+	panic("BUG: ProcessRequestBody should not be called in the upstream filter")
+}
+
+func (r *responsesProcessorUpstreamFilter) ProcessResponseHeaders(ctx context.Context, headers *corev3.HeaderMap) (res *extprocv3.ProcessingResponse, err error) {
+	defer func() {
+		if err != nil {
+			r.metrics.RecordRequestCompletion(ctx, false, r.requestHeaders)
+		}
+	}()
+
+	r.responseHeaders = headersToMap(headers)
+	if enc := r.responseHeaders["content-encoding"]; enc != "" {
+		r.responseEncoding = enc
+	}
+
+	headerMutation, err := r.translator.ResponseHeaders(r.responseHeaders)
+	if err != nil {
+		return nil, fmt.Errorf("failed to transform response headers: %w", err)
+	}
+
+	var mode *extprocv3http.ProcessingMode
+	if r.stream && r.responseHeaders[":status"] == "200" {
+		mode = &extprocv3http.ProcessingMode{ResponseBodyMode: extprocv3http.ProcessingMode_STREAMED}
+	}
+
+	return &extprocv3.ProcessingResponse{Response: &extprocv3.ProcessingResponse_ResponseHeaders{
+		ResponseHeaders: &extprocv3.HeadersResponse{
+			Response: &extprocv3.CommonResponse{HeaderMutation: headerMutation},
+		},
+	}, ModeOverride: mode}, nil
+}
+
+func (r *responsesProcessorUpstreamFilter) ProcessResponseBody(ctx context.Context, body *extprocv3.HttpBody) (resp *extprocv3.ProcessingResponse, err error) {
+	defer func() {
+		r.metrics.RecordRequestCompletion(ctx, err == nil, r.requestHeaders)
+	}()
+
+	var reader io.Reader
+	var isGzip bool
+	switch r.responseEncoding {
+	case "gzip":
+		reader, err = gzip.NewReader(bytes.NewReader(body.Body))
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode gzip: %w", err)
+		}
+		isGzip = true
+	default:
+		reader = bytes.NewReader(body.Body)
+	}
+
+	if code, _ := strconv.Atoi(r.responseHeaders[":status"]); !isGoodStatusCode(code) {
+		headerMutation, bodyMutation, err := r.translator.ResponseError(r.responseHeaders, reader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to transform response error: %w", err)
+		}
+		return &extprocv3.ProcessingResponse{
+			Response: &extprocv3.ProcessingResponse_ResponseBody{
+				ResponseBody: &extprocv3.BodyResponse{
+					Response: &extprocv3.CommonResponse{
+						HeaderMutation: headerMutation,
+						BodyMutation:   bodyMutation,
+					},
+				},
+			},
+		}, nil
+	}
+
+	headerMutation, bodyMutation, tokenUsage, latencyTokens, err := r.translator.ResponseBody(
+		r.responseHeaders, reader, body.EndOfStream,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to transform response: %w", err)
+	}
+	if bodyMutation != nil && isGzip {
+		if headerMutation == nil {
+			headerMutation = &extprocv3.HeaderMutation{}
+		}
+		headerMutation.RemoveHeaders = append(headerMutation.RemoveHeaders, "content-encoding")
+	}
+
+	resp = &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_ResponseBody{
+			ResponseBody: &extprocv3.BodyResponse{
+				Response: &extprocv3.CommonResponse{
+					HeaderMutation: headerMutation,
+					BodyMutation:   bodyMutation,
+				},
+			},
+		},
+	}
+
+	r.costs.InputTokens += tokenUsage.InputTokens
+	r.costs.OutputTokens += tokenUsage.OutputTokens
+	r.costs.TotalTokens += tokenUsage.TotalTokens
+
+	r.metrics.RecordTokenUsage(ctx, tokenUsage.InputTokens, tokenUsage.OutputTokens, tokenUsage.TotalTokens, r.requestHeaders)
+	if r.stream && latencyTokens > 0 {
+		r.metrics.RecordTokenLatency(ctx, latencyTokens, r.requestHeaders)
+	}
+
+	if body.EndOfStream && len(r.config.requestCosts) > 0 {
+		metadata, err := buildDynamicMetadata(r.config, &r.costs, r.requestHeaders, r.modelNameOverride, r.backendName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build dynamic metadata: %w", err)
+		}
+		if r.stream {
+			r.mergeWithTokenLatencyMetadata(metadata)
+		}
+		resp.DynamicMetadata = metadata
+	}
+
+	return resp, nil
+}
+
+func (r *responsesProcessorUpstreamFilter) SetBackend(ctx context.Context, backend *filterapi.Backend, backendHandler backendauth.Handler, routeProcessor Processor) (err error) {
+	defer func() {
+		r.metrics.RecordRequestCompletion(ctx, err == nil, r.requestHeaders)
+	}()
+
+	pickedEndpoint, isEndpointPicker := r.requestHeaders[internalapi.EndpointPickerHeaderKey]
+
+	rp, ok := routeProcessor.(*responsesProcessorRouterFilter)
+	if !ok {
+		panic("BUG: expected routeProcessor to be of type *responsesProcessorRouterFilter")
+	}
+	rp.upstreamFilterCount++
+
+	r.metrics.SetBackend(backend)
+	r.modelNameOverride = backend.ModelNameOverride
+	r.backendName = backend.Name
+	if err = r.selectTranslator(backend.Schema); err != nil {
+		return fmt.Errorf("failed to select translator: %w", err)
+	}
+
+	r.handler = backendHandler
+	r.headerMutator = headermutator.NewHeaderMutator(backend.HeaderMutation, rp.requestHeaders)
+	if r.modelNameOverride != "" {
+		r.requestHeaders[r.config.modelNameHeaderKey] = r.modelNameOverride
+	}
+
+	r.originalRequestBody = rp.originalRequestBody
+	r.originalRequestBodyRaw = rp.originalRequestBodyRaw
+	r.onRetry = rp.upstreamFilterCount > 1
+	if rp.originalRequestBody != nil {
+		r.stream = rp.originalRequestBody.Stream
+	}
+
+	if isEndpointPicker && r.logger.Enabled(ctx, slog.LevelDebug) {
+		r.logger.Debug("selected backend", slog.String("picked_endpoint", pickedEndpoint), slog.String("backendName", backend.Name), slog.String("modelNameOverride", r.modelNameOverride))
+	}
+
+	rp.upstreamFilter = r
+	return nil
+}
+
+func (r *responsesProcessorUpstreamFilter) mergeWithTokenLatencyMetadata(metadata *structpb.Struct) {
+	timeToFirstTokenMs := r.metrics.GetTimeToFirstTokenMs()
+	interTokenLatencyMs := r.metrics.GetInterTokenLatencyMs()
+	ns := r.config.metadataNamespace
+	innerVal := metadata.Fields[ns].GetStructValue()
+	if innerVal == nil {
+		innerVal = &structpb.Struct{Fields: map[string]*structpb.Value{}}
+		metadata.Fields[ns] = structpb.NewStructValue(innerVal)
+	}
+	innerVal.Fields["token_latency_ttft"] = &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: timeToFirstTokenMs}}
+	innerVal.Fields["token_latency_itl"] = &structpb.Value{Kind: &structpb.Value_NumberValue{NumberValue: interTokenLatencyMs}}
+}
+
+func parseOpenAIResponsesBody(body *extprocv3.HttpBody) (string, *openai.ResponsesRequest, error) {
+	var request openai.ResponsesRequest
+	if err := json.Unmarshal(body.Body, &request); err != nil {
+		return "", nil, fmt.Errorf("failed to unmarshal body: %w", err)
+	}
+	return request.Model, &request, nil
+}

--- a/internal/extproc/responses_processor.go
+++ b/internal/extproc/responses_processor.go
@@ -364,9 +364,27 @@ func (r *responsesProcessorUpstreamFilter) mergeWithTokenLatencyMetadata(metadat
 }
 
 func parseOpenAIResponsesBody(body *extprocv3.HttpBody) (string, *openai.ResponsesRequest, error) {
-	var request openai.ResponsesRequest
-	if err := json.Unmarshal(body.Body, &request); err != nil {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body.Body, &raw); err != nil {
 		return "", nil, fmt.Errorf("failed to unmarshal body: %w", err)
 	}
-	return request.Model, &request, nil
+	var req openai.ResponsesRequest
+	if m, ok := raw["model"]; ok {
+		if err := json.Unmarshal(m, &req.Model); err != nil {
+			return "", nil, fmt.Errorf("invalid model: %w", err)
+		}
+	}
+	if inp, ok := raw["input"]; ok {
+		req.Input = inp
+	}
+	if s, ok := raw["stream"]; ok {
+		var b bool
+		if err := json.Unmarshal(s, &b); err == nil {
+			req.Stream = b
+		} else {
+			// Non-boolean values (e.g., objects) enable streaming.
+			req.Stream = true
+		}
+	}
+	return req.Model, &req, nil
 }

--- a/internal/extproc/responses_processor_test.go
+++ b/internal/extproc/responses_processor_test.go
@@ -1,0 +1,199 @@
+package extproc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/filterapi"
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+	"github.com/envoyproxy/ai-gateway/internal/extproc/translator"
+	tracing "github.com/envoyproxy/ai-gateway/internal/tracing/api"
+)
+
+func TestResponses_Schema(t *testing.T) {
+	cfg := &processorConfig{}
+	factory := ResponsesProcessorFactory(nil)
+
+	t.Run("router", func(t *testing.T) {
+		proc, err := factory(cfg, nil, slog.Default(), tracing.NoopTracing{}, false)
+		require.NoError(t, err)
+		require.IsType(t, &responsesProcessorRouterFilter{}, proc)
+	})
+
+	t.Run("upstream", func(t *testing.T) {
+		proc, err := factory(cfg, nil, slog.Default(), tracing.NoopTracing{}, true)
+		require.NoError(t, err)
+		require.IsType(t, &responsesProcessorUpstreamFilter{}, proc)
+	})
+}
+
+func Test_responsesProcessorUpstreamFilter_SelectTranslator(t *testing.T) {
+	p := &responsesProcessorUpstreamFilter{}
+
+	require.ErrorContains(t, p.selectTranslator(filterapi.VersionedAPISchema{Name: "Unknown"}), "unsupported API schema")
+
+	require.NoError(t, p.selectTranslator(filterapi.VersionedAPISchema{Name: filterapi.APISchemaOpenAI}))
+	require.NotNil(t, p.translator)
+}
+
+func Test_responsesProcessorRouterFilter_ProcessRequestBody(t *testing.T) {
+	t.Run("invalid json", func(t *testing.T) {
+		p := &responsesProcessorRouterFilter{}
+		_, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: []byte("foo")})
+		require.ErrorContains(t, err, "failed to parse request body")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		headers := map[string]string{":path": "/v1/responses"}
+		p := &responsesProcessorRouterFilter{
+			config:         &processorConfig{modelNameHeaderKey: "x-model"},
+			requestHeaders: headers,
+			logger:         slog.Default(),
+		}
+		resp, err := p.ProcessRequestBody(t.Context(), &extprocv3.HttpBody{Body: responsesBodyFromModel(t, "some-model")})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		rb, ok := resp.Response.(*extprocv3.ProcessingResponse_RequestBody)
+		require.True(t, ok)
+		setHeaders := rb.RequestBody.GetResponse().GetHeaderMutation().SetHeaders
+		require.Len(t, setHeaders, 2)
+		require.Equal(t, "x-model", setHeaders[0].Header.Key)
+		require.Equal(t, "some-model", string(setHeaders[0].Header.RawValue))
+		require.Equal(t, originalPathHeader, setHeaders[1].Header.Key)
+		require.Equal(t, "/v1/responses", string(setHeaders[1].Header.RawValue))
+	})
+}
+
+func Test_responsesProcessorUpstreamFilter_ProcessResponseHeaders(t *testing.T) {
+	t.Run("translator error", func(t *testing.T) {
+		mt := &mockResponsesTranslator{t: t, expHeaders: make(map[string]string), retErr: errors.New("translator error")}
+		mm := &mockChatCompletionMetrics{}
+		p := &responsesProcessorUpstreamFilter{
+			translator: mt,
+			metrics:    mm,
+		}
+		_, err := p.ProcessResponseHeaders(context.Background(), &corev3.HeaderMap{})
+		require.ErrorContains(t, err, "translator error")
+		mm.RequireRequestFailure(t)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		headers := &corev3.HeaderMap{Headers: []*corev3.HeaderValue{{Key: "foo", Value: "bar"}}}
+		mt := &mockResponsesTranslator{t: t, expHeaders: map[string]string{"foo": "bar"}}
+		mm := &mockChatCompletionMetrics{}
+		p := &responsesProcessorUpstreamFilter{translator: mt, metrics: mm, responseHeaders: map[string]string{}, requestHeaders: map[string]string{}}
+
+		resp, err := p.ProcessResponseHeaders(context.Background(), headers)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		mm.RequireRequestNotCompleted(t)
+	})
+}
+
+func Test_responsesProcessorUpstreamFilter_ProcessResponseBody(t *testing.T) {
+	t.Run("translator error response", func(t *testing.T) {
+		mt := &mockResponsesTranslator{t: t, retHeaderMutation: &extprocv3.HeaderMutation{}, retBodyMutation: &extprocv3.BodyMutation{}, expResponseBody: &extprocv3.HttpBody{Body: []byte("oops")}}
+		mm := &mockChatCompletionMetrics{}
+		p := &responsesProcessorUpstreamFilter{
+			translator:      mt,
+			metrics:         mm,
+			responseHeaders: map[string]string{":status": "500"},
+		}
+		resp, err := p.ProcessResponseBody(context.Background(), &extprocv3.HttpBody{Body: []byte("oops"), EndOfStream: true})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		mm.RequireRequestSuccess(t)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		mt := &mockResponsesTranslator{
+			t:               t,
+			retUsedToken:    translator.LLMTokenUsage{InputTokens: 2, OutputTokens: 3, TotalTokens: 5},
+			expResponseBody: &extprocv3.HttpBody{Body: []byte("{}")},
+		}
+		mm := &mockChatCompletionMetrics{}
+		p := &responsesProcessorUpstreamFilter{
+			translator:      mt,
+			metrics:         mm,
+			responseHeaders: map[string]string{":status": "200"},
+			requestHeaders:  map[string]string{},
+			config:          &processorConfig{},
+		}
+		resp, err := p.ProcessResponseBody(context.Background(), &extprocv3.HttpBody{Body: []byte("{}"), EndOfStream: true})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		mm.RequireTokensRecorded(t, 1)
+		mm.RequireRequestSuccess(t)
+	})
+
+	t.Run("streaming latency metadata", func(t *testing.T) {
+		mt := &mockResponsesTranslator{
+			t:                t,
+			retUsedToken:     translator.LLMTokenUsage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3},
+			retLatencyTokens: 1,
+			expResponseBody:  &extprocv3.HttpBody{Body: []byte("{}")},
+		}
+		mm := &mockChatCompletionMetrics{}
+		p := &responsesProcessorUpstreamFilter{
+			translator:      mt,
+			metrics:         mm,
+			responseHeaders: map[string]string{":status": "200"},
+			requestHeaders:  map[string]string{"model": "foo"},
+			config: &processorConfig{
+				metadataNamespace:  "ai_gateway_llm_ns",
+				modelNameHeaderKey: "model",
+				requestCosts: []processorConfigRequestCost{{
+					LLMRequestCost: &filterapi.LLMRequestCost{
+						Type:        filterapi.LLMRequestCostTypeOutputToken,
+						MetadataKey: "output_token_usage",
+					},
+				}},
+			},
+			backendName:       "backend",
+			modelNameOverride: "model-override",
+			stream:            true,
+		}
+		resp, err := p.ProcessResponseBody(context.Background(), &extprocv3.HttpBody{Body: []byte("{}"), EndOfStream: true})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		mm.RequireTokensRecorded(t, 1)
+		mm.RequireRequestSuccess(t)
+
+		metadata := resp.DynamicMetadata.Fields["ai_gateway_llm_ns"].GetStructValue()
+		require.NotNil(t, metadata)
+		require.Equal(t, float64(2), metadata.Fields["output_token_usage"].GetNumberValue())
+		require.Equal(t, float64(1000), metadata.Fields["token_latency_ttft"].GetNumberValue())
+		require.Equal(t, float64(500), metadata.Fields["token_latency_itl"].GetNumberValue())
+		require.Equal(t, "model-override", metadata.Fields["model_name_override"].GetStringValue())
+		require.Equal(t, "backend", metadata.Fields["backend_name"].GetStringValue())
+	})
+}
+
+func responsesBodyFromModel(t *testing.T, model string) []byte {
+	t.Helper()
+	body := map[string]any{
+		"model": model,
+		"input": "hello",
+	}
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	return raw
+}
+
+func Test_parseOpenAIResponsesBody(t *testing.T) {
+	model, req, err := parseOpenAIResponsesBody(&extprocv3.HttpBody{Body: responsesBodyFromModel(t, "foo")})
+	require.NoError(t, err)
+	require.Equal(t, "foo", model)
+	require.Equal(t, "foo", req.Model)
+
+	_, _, err = parseOpenAIResponsesBody(&extprocv3.HttpBody{Body: []byte("not json")})
+	require.ErrorContains(t, err, "failed to unmarshal body")
+}

--- a/internal/extproc/responses_processor_test.go
+++ b/internal/extproc/responses_processor_test.go
@@ -193,6 +193,14 @@ func Test_parseOpenAIResponsesBody(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "foo", model)
 	require.Equal(t, "foo", req.Model)
+	require.False(t, req.Stream)
+
+	// Accept non-boolean stream values and treat them as enabling streaming.
+	raw, err := json.Marshal(map[string]any{"model": "bar", "input": "hi", "stream": map[string]any{"type": "sse"}})
+	require.NoError(t, err)
+	_, req, err = parseOpenAIResponsesBody(&extprocv3.HttpBody{Body: raw})
+	require.NoError(t, err)
+	require.True(t, req.Stream)
 
 	_, _, err = parseOpenAIResponsesBody(&extprocv3.HttpBody{Body: []byte("not json")})
 	require.ErrorContains(t, err, "failed to unmarshal body")

--- a/internal/extproc/translator/openai_responses_openai.go
+++ b/internal/extproc/translator/openai_responses_openai.go
@@ -1,0 +1,186 @@
+package translator
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path"
+	"strconv"
+	"strings"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/tidwall/sjson"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+)
+
+// NewResponsesOpenAIToOpenAITranslator returns a translator for the
+// /v1/responses endpoint when the backend is also OpenAI compatible.
+func NewResponsesOpenAIToOpenAITranslator(apiVersion string, modelNameOverride string) OpenAIResponsesTranslator {
+	return &openAIToOpenAITranslatorV1Responses{
+		modelNameOverride: modelNameOverride,
+		path:              path.Join("/", apiVersion, "responses"),
+	}
+}
+
+type openAIToOpenAITranslatorV1Responses struct {
+	modelNameOverride string
+	path              string
+	stream            bool
+	buffered          []byte
+	bufferingDone     bool
+}
+
+func (o *openAIToOpenAITranslatorV1Responses) RequestBody(original []byte, req *openai.ResponsesRequest, forceBodyMutation bool) (
+	headerMutation *extprocv3.HeaderMutation,
+	bodyMutation *extprocv3.BodyMutation,
+	err error,
+) {
+	if req != nil {
+		o.stream = req.Stream
+	}
+
+	var newBody []byte
+	if o.modelNameOverride != "" {
+		newBody, err = sjson.SetBytesOptions(original, "model", o.modelNameOverride, SJSONOptions)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to set model name: %w", err)
+		}
+	}
+
+	headerMutation = &extprocv3.HeaderMutation{
+		SetHeaders: []*corev3.HeaderValueOption{{
+			Header: &corev3.HeaderValue{
+				Key:      ":path",
+				RawValue: []byte(o.path),
+			},
+		}},
+	}
+
+	if forceBodyMutation && len(newBody) == 0 {
+		newBody = original
+	}
+
+	if len(newBody) > 0 {
+		bodyMutation = &extprocv3.BodyMutation{
+			Mutation: &extprocv3.BodyMutation_Body{Body: newBody},
+		}
+		headerMutation.SetHeaders = append(headerMutation.SetHeaders, &corev3.HeaderValueOption{
+			Header: &corev3.HeaderValue{
+				Key:      "content-length",
+				RawValue: []byte(strconv.Itoa(len(newBody))),
+			},
+		})
+	}
+
+	return
+}
+
+func (o *openAIToOpenAITranslatorV1Responses) ResponseHeaders(map[string]string) (*extprocv3.HeaderMutation, error) {
+	return nil, nil
+}
+
+func (o *openAIToOpenAITranslatorV1Responses) ResponseBody(_ map[string]string, body io.Reader, _ bool) (
+	headerMutation *extprocv3.HeaderMutation,
+	bodyMutation *extprocv3.BodyMutation,
+	tokenUsage LLMTokenUsage,
+	latencyTokens uint32,
+	err error,
+) {
+	if o.stream {
+		if o.bufferingDone {
+			return nil, nil, tokenUsage, 0, nil
+		}
+		buf, err := io.ReadAll(body)
+		if err != nil {
+			return nil, nil, tokenUsage, 0, fmt.Errorf("failed to read body: %w", err)
+		}
+		o.buffered = append(o.buffered, buf...)
+		tokenUsage, latencyTokens = o.extractUsageFromBufferEvent()
+		return nil, nil, tokenUsage, latencyTokens, nil
+	}
+
+	resp := &openai.ResponsesResponse{}
+	if err := json.NewDecoder(body).Decode(resp); err != nil {
+		return nil, nil, tokenUsage, 0, fmt.Errorf("failed to unmarshal body: %w", err)
+	}
+	tokenUsage = convertResponsesUsage(resp.Usage)
+	return nil, nil, tokenUsage, 0, nil
+}
+
+func (o *openAIToOpenAITranslatorV1Responses) ResponseError(respHeaders map[string]string, body io.Reader) (
+	headerMutation *extprocv3.HeaderMutation,
+	bodyMutation *extprocv3.BodyMutation,
+	err error,
+) {
+	statusCode := respHeaders[statusHeaderName]
+	if v, ok := respHeaders[contentTypeHeaderName]; ok && v != jsonContentType {
+		var openaiError openai.Error
+		buf, err := io.ReadAll(body)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to read error body: %w", err)
+		}
+		openaiError = openai.Error{
+			Type: "error",
+			Error: openai.ErrorType{
+				Type:    openAIBackendError,
+				Message: string(buf),
+				Code:    &statusCode,
+			},
+		}
+		mut := &extprocv3.BodyMutation_Body{}
+		mut.Body, err = json.Marshal(openaiError)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal error body: %w", err)
+		}
+		headerMutation = &extprocv3.HeaderMutation{}
+		setContentLength(headerMutation, mut.Body)
+		return headerMutation, &extprocv3.BodyMutation{Mutation: mut}, nil
+	}
+	return nil, nil, nil
+}
+
+func (o *openAIToOpenAITranslatorV1Responses) extractUsageFromBufferEvent() (tokenUsage LLMTokenUsage, latencyTokens uint32) {
+	for {
+		idx := bytes.IndexByte(o.buffered, '\n')
+		if idx == -1 {
+			return tokenUsage, latencyTokens
+		}
+		line := o.buffered[:idx]
+		o.buffered = o.buffered[idx+1:]
+		if !bytes.HasPrefix(line, dataPrefix) {
+			continue
+		}
+		payload := bytes.TrimPrefix(line, dataPrefix)
+		payload = bytes.TrimSpace(payload)
+		if len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) {
+			continue
+		}
+		event := &openai.ResponsesStreamEvent{}
+		if err := json.Unmarshal(payload, event); err != nil {
+			continue
+		}
+		if event.Type == "response.completed" {
+			if event.Response == nil {
+				continue
+			}
+			tokenUsage = convertResponsesUsage(event.Response.Usage)
+			o.buffered = nil
+			o.bufferingDone = true
+			return tokenUsage, latencyTokens
+		}
+		if strings.HasSuffix(event.Type, ".delta") {
+			latencyTokens++
+		}
+	}
+}
+
+func convertResponsesUsage(usage openai.ResponsesUsage) LLMTokenUsage {
+	return LLMTokenUsage{
+		InputTokens:  uint32(usage.InputTokens),
+		OutputTokens: uint32(usage.OutputTokens),
+		TotalTokens:  uint32(usage.TotalTokens),
+	}
+}

--- a/internal/extproc/translator/openai_responses_openai_test.go
+++ b/internal/extproc/translator/openai_responses_openai_test.go
@@ -1,0 +1,112 @@
+package translator
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
+)
+
+func Test_openAIToOpenAITranslatorV1Responses_RequestBody(t *testing.T) {
+	translator := NewResponsesOpenAIToOpenAITranslator("v1", "new-model")
+	original := []byte(`{"model":"old-model","stream":true}`)
+	req := &openai.ResponsesRequest{Model: "old-model", Stream: true}
+
+	header, body, err := translator.RequestBody(original, req, false)
+	require.NoError(t, err)
+	require.NotNil(t, header)
+	require.Len(t, header.SetHeaders, 1)
+	require.Equal(t, ":path", header.SetHeaders[0].Header.Key)
+	require.Equal(t, "/v1/responses", string(header.SetHeaders[0].Header.RawValue))
+
+	require.NotNil(t, body)
+	mutated := body.GetBody()
+	require.NotNil(t, mutated)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(mutated, &payload))
+	require.Equal(t, "new-model", payload["model"])
+	require.Equal(t, true, payload["stream"])
+}
+
+func Test_openAIToOpenAITranslatorV1Responses_ResponseBody(t *testing.T) {
+	translator := NewResponsesOpenAIToOpenAITranslator("v1", "")
+	_, _, err := translator.RequestBody([]byte(`{"model":"foo"}`), &openai.ResponsesRequest{Model: "foo"}, false)
+	require.NoError(t, err)
+
+	_, _, tokens, latencyTokens, err := translator.ResponseBody(nil, bytes.NewReader([]byte(`{"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}`)), true)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), tokens.InputTokens)
+	require.Equal(t, uint32(2), tokens.OutputTokens)
+	require.Equal(t, uint32(3), tokens.TotalTokens)
+	require.Equal(t, uint32(0), latencyTokens)
+}
+
+func Test_openAIToOpenAITranslatorV1Responses_ResponseBodyStreaming(t *testing.T) {
+	translator := NewResponsesOpenAIToOpenAITranslator("v1", "")
+	_, _, err := translator.RequestBody([]byte(`{"model":"foo","stream":true}`), &openai.ResponsesRequest{Model: "foo", Stream: true}, false)
+	require.NoError(t, err)
+
+	deltaPayload := "data: {\"type\":\"response.output_text.delta\"}\n"
+	_, _, tokens, latencyTokens, err := translator.ResponseBody(nil, bytes.NewBufferString(deltaPayload), false)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), tokens.TotalTokens)
+	require.Equal(t, uint32(1), latencyTokens)
+
+	streamPayload := "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":5,\"output_tokens\":6,\"total_tokens\":11}}}\n\n"
+	_, _, tokens, latencyTokens, err = translator.ResponseBody(nil, bytes.NewBufferString(streamPayload), false)
+	require.NoError(t, err)
+	require.Equal(t, uint32(5), tokens.InputTokens)
+	require.Equal(t, uint32(6), tokens.OutputTokens)
+	require.Equal(t, uint32(11), tokens.TotalTokens)
+	require.Equal(t, uint32(0), latencyTokens)
+}
+
+func Test_openAIToOpenAITranslatorV1Responses_ResponseError(t *testing.T) {
+	translator := NewResponsesOpenAIToOpenAITranslator("v1", "")
+	headers := map[string]string{statusHeaderName: "500", contentTypeHeaderName: "text/plain"}
+
+	headerMutation, bodyMutation, err := translator.ResponseError(headers, bytes.NewBufferString("backend failure"))
+	require.NoError(t, err)
+	require.NotNil(t, headerMutation)
+	require.NotNil(t, bodyMutation)
+
+	body := bodyMutation.GetBody()
+	require.NotNil(t, body)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(body, &parsed))
+	require.Equal(t, "error", parsed["type"])
+}
+
+func Test_openAIToOpenAITranslatorV1Responses_ResponseBody_NoStreamingUsageUntilBuffered(t *testing.T) {
+	translator := NewResponsesOpenAIToOpenAITranslator("v1", "")
+	_, _, err := translator.RequestBody([]byte(`{"model":"foo","stream":true}`), &openai.ResponsesRequest{Model: "foo", Stream: true}, false)
+	require.NoError(t, err)
+
+	// First chunk does not contain usage yet.
+	_, _, tokens, latencyTokens, err := translator.ResponseBody(nil, bytes.NewBufferString("data: {\"type\":\"response.created\"}\n"), false)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), tokens.TotalTokens)
+	require.Equal(t, uint32(0), latencyTokens)
+
+	// Usage chunk should now be extracted.
+	_, _, tokens, latencyTokens, err = translator.ResponseBody(nil, bytes.NewBufferString("data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":2,\"output_tokens\":4,\"total_tokens\":6}}}\n"), true)
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), tokens.InputTokens)
+	require.Equal(t, uint32(4), tokens.OutputTokens)
+	require.Equal(t, uint32(6), tokens.TotalTokens)
+	require.Equal(t, uint32(0), latencyTokens)
+}
+
+func Test_openAIToOpenAITranslatorV1Responses_ResponseBody_ErrorWhenInvalidJSON(t *testing.T) {
+	translator := NewResponsesOpenAIToOpenAITranslator("v1", "")
+	_, _, err := translator.RequestBody([]byte(`{"model":"foo"}`), &openai.ResponsesRequest{Model: "foo"}, false)
+	require.NoError(t, err)
+
+	_, _, _, _, err = translator.ResponseBody(nil, bytes.NewBufferString("{invalid"), true)
+	require.Error(t, err)
+}

--- a/internal/extproc/translator/translator.go
+++ b/internal/extproc/translator/translator.go
@@ -69,6 +69,44 @@ type OpenAIChatCompletionTranslator interface {
 	ResponseError(respHeaders map[string]string, body io.Reader) (headerMutation *extprocv3.HeaderMutation, bodyMutation *extprocv3.BodyMutation, err error)
 }
 
+// OpenAIResponsesTranslator translates requests and responses for the
+// /v1/responses endpoint when using the OpenAI schema.
+//
+// This translator mirrors the behaviour of the chat completion translator but
+// omits tracing specific parameters as responses currently do not emit spans.
+type OpenAIResponsesTranslator interface {
+	RequestBody(raw []byte, body *openai.ResponsesRequest, forceBodyMutation bool) (
+		headerMutation *extprocv3.HeaderMutation,
+		bodyMutation *extprocv3.BodyMutation,
+		err error,
+	)
+
+	ResponseHeaders(headers map[string]string) (
+		headerMutation *extprocv3.HeaderMutation,
+		err error,
+	)
+
+	// ResponseBody translates the response body. When stream=true, this is called for each chunk of the response body.
+	//      - `body` is the response body either chunk or the entire body, depending on the context.
+	//      - This returns `headerMutation` and `bodyMutation` that can be nil to indicate no mutation.
+	//      - This returns `tokenUsage` that is extracted from the body and will be used to do token rate limiting.
+	//      - `latencyTokens` represents the number of streamed delta events in the chunk and is used to populate token
+	//        latency metrics when usage is only emitted at the end of a stream.
+	ResponseBody(respHeaders map[string]string, body io.Reader, endOfStream bool) (
+		headerMutation *extprocv3.HeaderMutation,
+		bodyMutation *extprocv3.BodyMutation,
+		tokenUsage LLMTokenUsage,
+		latencyTokens uint32,
+		err error,
+	)
+
+	ResponseError(respHeaders map[string]string, body io.Reader) (
+		headerMutation *extprocv3.HeaderMutation,
+		bodyMutation *extprocv3.BodyMutation,
+		err error,
+	)
+}
+
 func setContentLength(headers *extprocv3.HeaderMutation, body []byte) {
 	headers.SetHeaders = append(headers.SetHeaders, &corev3.HeaderValueOption{
 		Header: &corev3.HeaderValue{

--- a/tests/internal/testupstreamlib/testupstream/main.go
+++ b/tests/internal/testupstreamlib/testupstream/main.go
@@ -440,6 +440,12 @@ func getFakeResponse(path string) ([]byte, error) {
 			chatCompletionFakeResponses[rand.New(rand.NewSource(uint64(time.Now().UnixNano()))).
 				Intn(len(chatCompletionFakeResponses))])
 		return []byte(msg), nil
+	case "/v1/responses":
+		const responsesTemplate = `{"id":"resp-test","output":[{"content":[{"type":"output_text","text":"%s"}],"type":"message"}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`
+		msg := fmt.Sprintf(responsesTemplate,
+			chatCompletionFakeResponses[rand.New(rand.NewSource(uint64(time.Now().UnixNano()))).
+				Intn(len(chatCompletionFakeResponses))])
+		return []byte(msg), nil
 	case "/v1/embeddings":
 		const embeddingTemplate = `{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2,0.3,0.4,0.5],"index":0}],"model":"some-cool-self-hosted-model","usage":{"prompt_tokens":3,"total_tokens":3}}`
 		return []byte(embeddingTemplate), nil


### PR DESCRIPTION
## Summary
- compute latency token counts when parsing OpenAI responses SSE streams so latency metrics fire even though usage arrives only at completion
- record streaming latency via translator-provided counts while keeping token usage accounting and dynamic metadata intact
- extend translator and processor unit tests to cover SSE delta handling and streaming metadata

## Testing
- `go test ./internal/extproc -run Test_responsesProcessorUpstreamFilter_ProcessResponseBody -count=1 -v` *(hangs while attempting to download Go module dependencies in the container)*


------
https://chatgpt.com/codex/tasks/task_i_68bf2e3ea09883249564254d231a226d