### PR TITLE
Add Go CI workflow and harden module downloads

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,0 +1,27 @@
+name: go-ci
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: Harden module downloads
+        run: |
+          go env -w GOPROXY=https://proxy.golang.org,direct
+          go env -w GOSUMDB=sum.golang.org
+          go mod download
+      - name: Build
+        run: go build ./...
+      - name: Unit tests (no cache)
+        run: go test ./... -count=1 -v

--- a/cmd/aigw/docker-compose-otel.yaml
+++ b/cmd/aigw/docker-compose-otel.yaml
@@ -16,7 +16,10 @@ services:
     volumes:
       - ../..:/workspace
       - aigw-target:/workspace/out
-    command: ["bash", "-c", "go build -buildvcs=false -o /workspace/out/aigw ./cmd/aigw"]
+    environment:
+      GOPROXY: https://proxy.golang.org,direct
+      GOSUMDB: sum.golang.org
+    command: ["bash", "-c", "go mod download && go build -buildvcs=false -o /workspace/out/aigw ./cmd/aigw"]
 
   # phoenix is an OpenTelemetry compatible LLM eval system which accepts trace
   # spans and has special handling for OpenInference LLM semantic conventions.

--- a/cmd/aigw/docker-compose.yaml
+++ b/cmd/aigw/docker-compose.yaml
@@ -17,7 +17,10 @@ services:
     volumes:
       - ../..:/workspace
       - aigw-target:/workspace/out
-    command: ["bash", "-c", "go build -buildvcs=false -o /workspace/out/aigw ./cmd/aigw"]
+    environment:
+      GOPROXY: https://proxy.golang.org,direct
+      GOSUMDB: sum.golang.org
+    command: ["bash", "-c", "go mod download && go build -buildvcs=false -o /workspace/out/aigw ./cmd/aigw"]
 
   # ollama-pull pulls the models defined in .env.ollama, to avoid 404s.
   ollama-pull:

--- a/internal/extproc/mocks_test.go
+++ b/internal/extproc/mocks_test.go
@@ -96,6 +96,7 @@ type mockResponsesTranslator struct {
 	retHeaderMutation           *extprocv3.HeaderMutation
 	retBodyMutation             *extprocv3.BodyMutation
 	retUsedToken                translator.LLMTokenUsage
+	retLatencyTokens            uint32
 	retErr                      error
 	expForceRequestBodyMutation bool
 }

--- a/internal/extproc/responses_processor.go
+++ b/internal/extproc/responses_processor.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"strconv"
+	"strings"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	extprocv3http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
@@ -373,6 +374,9 @@ func parseOpenAIResponsesBody(body *extprocv3.HttpBody) (string, *openai.Respons
 		if err := json.Unmarshal(m, &req.Model); err != nil {
 			return "", nil, fmt.Errorf("invalid model: %w", err)
 		}
+	}
+	if strings.TrimSpace(req.Model) == "" {
+		return "", nil, fmt.Errorf("missing required field: model")
 	}
 	if inp, ok := raw["input"]; ok {
 		req.Input = inp

--- a/internal/extproc/responses_processor_test.go
+++ b/internal/extproc/responses_processor_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/envoyproxy/ai-gateway/filterapi"
-	"github.com/envoyproxy/ai-gateway/internal/apischema/openai"
 	"github.com/envoyproxy/ai-gateway/internal/extproc/translator"
 	tracing "github.com/envoyproxy/ai-gateway/internal/tracing/api"
 )
@@ -201,6 +200,9 @@ func Test_parseOpenAIResponsesBody(t *testing.T) {
 	_, req, err = parseOpenAIResponsesBody(&extprocv3.HttpBody{Body: raw})
 	require.NoError(t, err)
 	require.True(t, req.Stream)
+
+	_, _, err = parseOpenAIResponsesBody(&extprocv3.HttpBody{Body: []byte(`{"input":"hi"}`)})
+	require.ErrorContains(t, err, "missing required field: model")
 
 	_, _, err = parseOpenAIResponsesBody(&extprocv3.HttpBody{Body: []byte("not json")})
 	require.ErrorContains(t, err, "failed to unmarshal body")

--- a/tests/extproc/vcr/docker-compose-otel.yaml
+++ b/tests/extproc/vcr/docker-compose-otel.yaml
@@ -14,7 +14,10 @@ services:
     volumes:
       - ../../..:/workspace
       - extproc-target:/workspace/out
-    command: ["bash", "-c", "go build -buildvcs=false -o /workspace/out/extproc ./cmd/extproc"]
+    environment:
+      GOPROXY: https://proxy.golang.org,direct
+      GOSUMDB: sum.golang.org
+    command: ["bash", "-c", "go mod download && go build -buildvcs=false -o /workspace/out/extproc ./cmd/extproc"]
 
   phoenix:
     image: arizephoenix/phoenix:latest

--- a/tests/extproc/vcr/docker-compose.yaml
+++ b/tests/extproc/vcr/docker-compose.yaml
@@ -15,7 +15,10 @@ services:
     volumes:
       - ../../..:/workspace
       - extproc-target:/workspace/out
-    command: ["bash", "-c", "go build -buildvcs=false -o /workspace/out/extproc ./cmd/extproc"]
+    environment:
+      GOPROXY: https://proxy.golang.org,direct
+      GOSUMDB: sum.golang.org
+    command: ["bash", "-c", "go mod download && go build -buildvcs=false -o /workspace/out/extproc ./cmd/extproc"]
 
   extproc:
     image: debian:trixie-slim


### PR DESCRIPTION
## Summary
- add a minimal go-ci workflow that builds the module and runs unit tests on pushes and pull requests
- preconfigure docker-compose build containers to pre-download modules using the Go proxy and checksum db
- validate responses requests require a non-empty model and update tests/mocks accordingly

## Testing
- go test ./internal/extproc -run Test_parseOpenAIResponsesBody -count=1 -v

------
https://chatgpt.com/codex/tasks/task_i_68bf7495e1ec8324bd924998fa996c05